### PR TITLE
Relax folding constraint for symmetry

### DIFF
--- a/src/sigmapie/ostia.py
+++ b/src/sigmapie/ostia.py
@@ -296,7 +296,7 @@ def ostia_fold(T_orig, q1, q2):
                         edge_defined = True
 
                         # fail if inconsistent with output of q2
-                        if tr_1[2] not in prefix(tr_2[2]):
+                        if tr_1[2] not in prefix(tr_2[2]) and tr_2[2] not in prefix(tr_1[2]):
                             return False
 
                         # move the mismatched suffix of q1 and q2 further


### PR DESCRIPTION
The effect that this has on the overall correctness of the implementation is unclear. Empirically, though, with this modification, [subregular experiments](https://github.com/alenaks/subregular-experiments/) 3 and 5 (single and double harmones with blockers) now fully converge in the original setting of (Aksënova 2020). Experiment 7 (two independent harmonies with blockers) only displays near-convergence with >99% accuracy, which is an admittedly strange result.